### PR TITLE
Style calendar item page

### DIFF
--- a/app/assets/stylesheets/comfy/admin/cms/custom.scss
+++ b/app/assets/stylesheets/comfy/admin/cms/custom.scss
@@ -612,4 +612,20 @@ footer {
   margin-right: 0 !important;
 }
 
+.btn-primary{
+  margin-left: 40px;
+}
+
+#custom {
+  margin-left: -20px;
+}
+
+#custom-edit {
+  margin-left: 0;
+}
+
+#calendar-edit {
+  margin-top: 30px;
+}
+
 /*# sourceMappingURL=styles.css.map */

--- a/app/views/admin/calendar_items/edit.html.erb
+++ b/app/views/admin/calendar_items/edit.html.erb
@@ -1,16 +1,35 @@
+<script>
+  var noon = new Date();
+  noon.setHours(12);
+  noon.setMinutes(0);
+  noon.setSeconds(0);
+  window.onload = function(){
+    var picker = new Pikaday({
+      field: document.getElementById('datepicker'),
+      format: 'MM/DD/YYYY hh:mm a',
+      incrementMinuteBy: 15,
+      defaultDate: noon,
+      onSelect: function() {
+       console.log(this.getMoment().format('Do MMMM YYYY'));
+      }
+    });
+  }
+</script>
 <article id="calendar-edit">
    <h1>Edit Event</h1>
    <dl id="meta-top">
 
      <%= form_for([:admin, @calendar_item]) do |f| %>
+     <div class="form-group">
            <dt><%= f.label :title %></dt>
-           <dd><%= f.text_field :title %></dd>
+           <dd><%= f.text_field :title, class: "form-control" %></dd>
 
             <dt><%= f.label :body %></dt>
-            <dd><%= f.text_area :body %></dd>
+            <dd><%= f.text_area :body, class: "form-control" %></dd>
 
            <dt><%= f.label :start_time %></dt>
-           <dd id="lesson-date" name ="lesson-date"><%= f.text_field :start_time %></dd>
+     </div>
+           <dd id="lesson-date" name ="lesson-date"><%= f.text_field :start_time, id: "datepicker", class: "form-control", type: "datetime"%></dd>
        <%= f.submit "Update Calendar", class: " btn btn-primary", style: "margin-top: 10px" %>
      <% end %>
  </article>

--- a/app/views/admin/calendar_items/edit.html.erb
+++ b/app/views/admin/calendar_items/edit.html.erb
@@ -30,6 +30,6 @@
            <dt><%= f.label :start_time %></dt>
      </div>
            <dd id="lesson-date" name ="lesson-date"><%= f.text_field :start_time, id: "datepicker", class: "form-control", type: "datetime"%></dd>
-       <%= f.submit "Update Calendar", class: " btn btn-primary", style: "margin-top: 10px" %>
+       <%= f.submit "Update Calendar", class: " btn btn-primary", id: "custom-edit", style: "margin-top: 10px" %>
      <% end %>
  </article>

--- a/app/views/admin/calendar_items/new.html.erb
+++ b/app/views/admin/calendar_items/new.html.erb
@@ -15,8 +15,8 @@
     });
   }
 </script>
-
 <%= form_for [:admin, @calendar_item] do |f| %>
+<form>
 <div class="form-group">
   <ul>
     <li>
@@ -34,7 +34,9 @@
       <%= f.text_field :start_time, id: 'datepicker',class: "form-control", type: "datetime" %>
     </li>
   </ul>
-</div>
+
 
   <%= f.submit "Create Calendar", class: "btn btn-primary" %>
 <% end %>
+</div>
+</form>

--- a/app/views/admin/calendar_items/new.html.erb
+++ b/app/views/admin/calendar_items/new.html.erb
@@ -17,22 +17,24 @@
 </script>
 
 <%= form_for [:admin, @calendar_item] do |f| %>
+<div class="form-group">
   <ul>
     <li>
       <%= f.label :title %>
-      <%= f.text_field :title %>
+      <%= f.text_field :title, class: "form-control" %>
     </li>
 
     <li>
       <%= f.label :body %>
-      <%= f.text_area :body %>
+      <%= f.text_area :body, class: "form-control" %>
     </li>
 
     <li>
       <%= f.label :start_time %>
-      <%= f.text_field :start_time, id: 'datepicker' %>
+      <%= f.text_field :start_time, id: 'datepicker',class: "form-control", type: "datetime" %>
     </li>
   </ul>
+</div>
 
   <%= f.submit "Create Calendar", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/admin/calendar_items/show.html.erb
+++ b/app/views/admin/calendar_items/show.html.erb
@@ -13,9 +13,9 @@
   </dl>
 
 
-  <%= button_to("Edit Event", edit_admin_calendar_item_url(@calendar_item), method: :get, class: "btn btn-primary") %>
+  <%= button_to("Edit Event", edit_admin_calendar_item_url(@calendar_item), method: :get, class: "btn btn-primary", id: "custom") %>
   <br>
 
-  <%= button_to("Delete Event", admin_calendar_item_path(@calendar_item), method: :delete, class: "btn btn-primary") %>
+  <%= button_to("Delete Event", admin_calendar_item_path(@calendar_item), method: :delete, class: "btn btn-primary", id: "custom") %>
 </article>
 </div>

--- a/app/views/admin/calendar_items/show.html.erb
+++ b/app/views/admin/calendar_items/show.html.erb
@@ -1,15 +1,21 @@
 <article id="calendaritem">
   <dl id="meta-top">
-    <dt>Title</dt>
+  <div class="form-group row">
+    <dt>Title:</dt>
+    <br>
       <dd><%= @calendar_item.title %></dd>
-    <dt>Date</dt>
-      <dd><%= @calendar_item.start_time %></dd>
-      <dt>Body</dt>
+      <dt>Body:</dt>
+      <br>
       <p><%= @calendar_item.body %></p>
+       <dt>Date:</dt>
+    <br>
+      <dd><%= @calendar_item.start_time %></dd>
   </dl>
+
 
   <%= button_to("Edit Event", edit_admin_calendar_item_url(@calendar_item), method: :get, class: "btn btn-primary") %>
   <br>
 
   <%= button_to("Delete Event", admin_calendar_item_path(@calendar_item), method: :delete, class: "btn btn-primary") %>
 </article>
+</div>


### PR DESCRIPTION
the new create page
<img width="541" alt="screen shot 2017-07-16 at 10 54 41 pm" src="https://user-images.githubusercontent.com/9599485/28254382-4b761ef2-6a7a-11e7-927b-95796320bcf3.png">

the new edit page 
<img width="1003" alt="screen shot 2017-07-16 at 10 53 59 pm" src="https://user-images.githubusercontent.com/9599485/28254377-33b6d36a-6a7a-11e7-940f-56d977307d53.png">

the new edit page with datepicker
<img width="926" alt="screen shot 2017-07-16 at 10 54 13 pm" src="https://user-images.githubusercontent.com/9599485/28254342-d76af55a-6a79-11e7-99de-e2ccd5b79f64.png">

the new show page 
<img width="423" alt="screen shot 2017-07-16 at 10 59 14 pm" src="https://user-images.githubusercontent.com/9599485/28254392-6ff2c9ce-6a7a-11e7-9556-d391731059b4.png">

the edit page was too close to the header therefore added `margin-top:30px` seems responsive

wanted the buttons to align nicely with the rest of the form made changes in custom.scss
